### PR TITLE
Use authomatic.core.User attributes instead of raw provider data.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,14 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use authomatic.core.User attributes instead of raw provider data. closes `#9`_
+  [ericof]
 
 
 1.0a1 (2015-10-28)
 ------------------
 
 - Initial release.
+
+
+.. _`#9`: https://github.com/collective/pas.plugins.authomatic/issues/9

--- a/README.rst
+++ b/README.rst
@@ -133,8 +133,8 @@ Development
 There must be an ``python`` binary available in system path pointing to Python 2.7.
 Also you need to have all installed to develop with Plone (see http://docs.plone.org/) then:
 
-- Plone 4: ``bootstrap-4.3.x.sh``
-- Plone 5: ``$ bootstrap-4.3.x.sh``
+- Plone 4: ``$ bootstrap-4.3.x.sh``
+- Plone 5: ``$ bootstrap-5.0.x.sh``
 
 
 License

--- a/src/pas/plugins/authomatic/plugin.py
+++ b/src/pas/plugins/authomatic/plugin.py
@@ -62,10 +62,19 @@ class AuthomaticPlugin(BasePlugin):
 
     def _make_sheet(self, user, propmap):
         pdata = dict(id=user.id)
+        user_dict = user.to_dict()
+
         for akey, pkey in propmap.items():
-            ainfo = user.data.get(akey, None)
+            # Always search first on the user attributes, then on the raw data
+            # this guaratees we do not break existing configurations
+            ainfo = user_dict.get(akey, user_dict['data'].get(akey, None))
             if ainfo is not None:
-                pdata[pkey] = ainfo
+                if isinstance(pkey, dict):
+                    for k, v in pkey.items():
+                        pdata[k] = ainfo.get(v)
+                else:
+                    pdata[pkey] = ainfo
+
         sheet = UserPropertySheet(**pdata)
         return sheet
 

--- a/src/pas/plugins/authomatic/tests/test_plugin.py
+++ b/src/pas/plugins/authomatic/tests/test_plugin.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from pas.plugins.authomatic.testing import PAS_PLUGINS_Authomatic_ZOPE_FIXTURE
+from Products.PluggableAuthService.UserPropertySheet import UserPropertySheet
+
 import unittest
 
 
@@ -117,3 +119,90 @@ class TestPlugin(unittest.TestCase):
             4,
             len(self.plugin.enumerateUsers())
         )
+
+
+class TestPropertyMapping(unittest.TestCase):
+
+    layer = PAS_PLUGINS_Authomatic_ZOPE_FIXTURE
+
+    def _make_provider(self, provider_name='Plone'):
+        class MockProvider(object):
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        return MockProvider(name=provider_name)
+
+    def _make_one(self, data=None):
+        from authomatic.core import User
+
+        provider = self._make_provider()
+        if not data:
+            data = {
+                u'displayName': u'Andrew Pipkin',
+                u'domain': u'foobar.com',
+                u'emails': [{u'type': u'account', u'value': u'andrewpipkin@foobar.com'}],
+                u'etag': u'"xxxxxxxxxxxx/xxxxxxxxxxxx"',
+                u'id': u'123456789',
+                u'image': {u'isDefault': False,
+                           u'url': u'https://lh3.googleusercontent.com/photo.jpg?sz=50'},
+                u'isPlusUser': False,
+                u'kind': u'plus#person',
+                u'language': u'en_GB',
+                u'name': {u'familyName': u'Pipkin', u'givenName': u'Andrew'},
+                u'objectType': u'person',
+                u'verified': False
+            }
+        user = User(provider)
+        user.data = data
+        user.id = u'123456789'
+        user.username = u'andrewpipkin'
+        user.name = u'Andrew Pipkin'
+        user.first_name = u'Andrew'
+        user.last_name = u'Pipkin'
+        user.nickname = u'Andy'
+        user.link = u'http://peterhudec.github.io/authomatic/'
+        user.email = u'andrewpipkin@foobar.com'
+        user.picture = u'https://lh3.googleusercontent.com/photo.jpg?sz=50'
+        user.location = u'Innsbruck'
+        return user
+
+    def _make_propmap(self):
+        return {
+            'email': 'email',
+            'link': 'home_page',
+            'location': 'location',
+            'name': 'fullname'
+        }
+
+    def setUp(self):
+        # create plugin
+        from pas.plugins.authomatic.setuphandlers import _add_plugin
+        self.aclu = self.layer['app'].acl_users
+        _add_plugin(self.aclu, 'authomatic')
+        self.plugin = self.aclu['authomatic']
+
+    def test_existing_user_attributes(self):
+        user = self._make_one()
+        propmap = self._make_propmap()
+        result = self.plugin._make_sheet(user, propmap)
+        self.assertIsInstance(result, UserPropertySheet)
+        self.assertEqual(
+            result.getProperty('home_page'), u'http://peterhudec.github.io/authomatic/'
+        )
+        self.assertEqual(result.getProperty('fullname'), u'Andrew Pipkin')
+        self.assertEqual(result.getProperty('email'), u'andrewpipkin@foobar.com')
+
+    def test_provider_specific_user_attributes(self):
+        user = self._make_one()
+        propmap = self._make_propmap()
+        propmap['data'] = {'domain': 'domain'}
+
+        result = self.plugin._make_sheet(user, propmap)
+        self.assertIsInstance(result, UserPropertySheet)
+        self.assertEqual(
+            result.getProperty('home_page'), u'http://peterhudec.github.io/authomatic/'
+        )
+        self.assertEqual(result.getProperty('fullname'), u'Andrew Pipkin')
+        self.assertEqual(result.getProperty('email'), u'andrewpipkin@foobar.com')
+        self.assertEqual(result.getProperty('domain'), u'foobar.com')

--- a/src/pas/plugins/authomatic/tests/test_plugin.py
+++ b/src/pas/plugins/authomatic/tests/test_plugin.py
@@ -141,11 +141,15 @@ class TestPropertyMapping(unittest.TestCase):
             data = {
                 u'displayName': u'Andrew Pipkin',
                 u'domain': u'foobar.com',
-                u'emails': [{u'type': u'account', u'value': u'andrewpipkin@foobar.com'}],
+                u'emails': [
+                    {u'type': u'account', u'value': u'andrewpipkin@foobar.com'}
+                ],
                 u'etag': u'"xxxxxxxxxxxx/xxxxxxxxxxxx"',
                 u'id': u'123456789',
-                u'image': {u'isDefault': False,
-                           u'url': u'https://lh3.googleusercontent.com/photo.jpg?sz=50'},
+                u'image': {
+                    u'isDefault': False,
+                    u'url': u'https://lh3.googleusercontent.com/photo.jpg'
+                },
                 u'isPlusUser': False,
                 u'kind': u'plus#person',
                 u'language': u'en_GB',
@@ -188,10 +192,14 @@ class TestPropertyMapping(unittest.TestCase):
         result = self.plugin._make_sheet(user, propmap)
         self.assertIsInstance(result, UserPropertySheet)
         self.assertEqual(
-            result.getProperty('home_page'), u'http://peterhudec.github.io/authomatic/'
+            result.getProperty('home_page'),
+            u'http://peterhudec.github.io/authomatic/'
         )
         self.assertEqual(result.getProperty('fullname'), u'Andrew Pipkin')
-        self.assertEqual(result.getProperty('email'), u'andrewpipkin@foobar.com')
+        self.assertEqual(
+            result.getProperty('email'),
+            u'andrewpipkin@foobar.com'
+        )
 
     def test_provider_specific_user_attributes(self):
         user = self._make_one()
@@ -201,8 +209,12 @@ class TestPropertyMapping(unittest.TestCase):
         result = self.plugin._make_sheet(user, propmap)
         self.assertIsInstance(result, UserPropertySheet)
         self.assertEqual(
-            result.getProperty('home_page'), u'http://peterhudec.github.io/authomatic/'
+            result.getProperty('home_page'),
+            u'http://peterhudec.github.io/authomatic/'
         )
         self.assertEqual(result.getProperty('fullname'), u'Andrew Pipkin')
-        self.assertEqual(result.getProperty('email'), u'andrewpipkin@foobar.com')
+        self.assertEqual(
+            result.getProperty('email'),
+            u'andrewpipkin@foobar.com'
+        )
         self.assertEqual(result.getProperty('domain'), u'foobar.com')


### PR DESCRIPTION
Somre comments:
* Look for the key from propertymap both in the attributes of user and inside user.data -- To avoid breaking existing configurations
* Not deal with nested objects inside user.data