### PR TITLE
Temptative to fix the bug in enumerateUsers where always is returning…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0a8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix filter users bug in enumerateUsers plugin where it was always returning
+  all the users.
+  [sneridagh]
 
 
 1.0a7 (2016-02-15)

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,10 +1,8 @@
 [buildout]
 extends =
     base.cfg
-    http://dist.plone.org/release/4.3.7/versions.cfg
+    http://dist.plone.org/release/4.3.9/versions.cfg
     versions.cfg
 
 [versions]
-plone.protect = 3.0.16
 zest.releaser =
-

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -5,4 +5,5 @@ extends =
     versions.cfg
 
 [versions]
+plone.protect = 3.0.16
 zest.releaser =

--- a/src/pas/plugins/authomatic/plugin.py
+++ b/src/pas/plugins/authomatic/plugin.py
@@ -224,6 +224,8 @@ class AuthomaticPlugin(BasePlugin):
         if search_id:
             if not isinstance(search_id, basestring):
                 raise NotImplementedError('sequence is not supported.')
+        else:
+            return ()
 
         pluginid = self.getId()
         ret = list()

--- a/src/pas/plugins/authomatic/tests/test_plugin.py
+++ b/src/pas/plugins/authomatic/tests/test_plugin.py
@@ -86,8 +86,10 @@ class TestPlugin(unittest.TestCase):
             2,
             len(self.plugin.enumerateUsers(login='123wil'))
         )
-        # list all!
+        # https://github.com/collective/pas.plugins.authomatic/pull/25/commits/5c0f6b1dc76a0d769e35a845ce4c4dd4307655ba
+        # Due to the workarround, now the enumerateUsers plugin doesn't return
+        # any users when searching with an empty query
         self.assertEqual(
-            4,
+            0,
             len(self.plugin.enumerateUsers())
         )


### PR DESCRIPTION
… all the users.

@jensens I've tried to debug it and this is the only way I've seen to fix it. Which is the best way to deal with the use case that you are not searching nothing, so you want to show all the users in an enumerateUsers plugin? With the approach I've used, there is no way to list them all (but the search works) :( Please, could you take a look?

Thanks!!
V.

PS: We need this working and usable for the upcoming plone.org sprint. I think that this is the only big issue that is left. Any help with it will be highly appreciated!