### PR TITLE
avoid ComponentLookupError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 1.0b2 (unreleased)
 ------------------
+- Include permissions from CMFCore to avoid ComponentLookupError.
+  [bsuttor]
 
 - Add french translation
   [mpeeters]

--- a/src/pas/plugins/authomatic/browser/configure.zcml
+++ b/src/pas/plugins/authomatic/browser/configure.zcml
@@ -18,6 +18,7 @@
       zcml:condition="not-have plone-5"
   />
 
+  <include package="Products.CMFCore" file="permissions.zcml" />
   <!-- Control panel -->
   <browser:page
       class=".controlpanel.AuthomaticSettingsEditFormSettingsControlPanel"


### PR DESCRIPTION
Include permission from CMFCore to avoid error
https://docs.plone.org/manage/troubleshooting/exceptions.html#componentlookuperror-cmf-manageportal