### PR TITLE
Fix zope5 error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b2 (unreleased)
 ------------------
 
+- Fixed ModuleNotFoundError: No module named 'App.class_init' on Zope 5.
+  [bsuttor]
+
 - Add french translation
   [mpeeters]
 

--- a/constraints_plone43.txt
+++ b/constraints_plone43.txt
@@ -1,2 +1,2 @@
-setuptools==27.3.0
-zc.buildout==2.5.3
+setuptools==38.7.0
+zc.buildout==2.13.4

--- a/src/pas/plugins/authomatic/integration.py
+++ b/src/pas/plugins/authomatic/integration.py
@@ -25,11 +25,11 @@ class ZopeRequestAdapter(BaseAdapter):
     @property
     def url(self):
         url = (
-            self.view.context.absolute_url() +
-            '/authomatic-handler/' +
-            self.view.provider
+            self.view.context.absolute_url()
+            + "/authomatic-handler/"
+            + self.view.provider
         )
-        logger.debug('url' + url)
+        logger.debug("url" + url)
         return url
 
     @property
@@ -40,7 +40,7 @@ class ZopeRequestAdapter(BaseAdapter):
     def cookies(self):
         # special handling since zope parsing does to much decoding
         cookie = six.moves.http_cookies.SimpleCookie()
-        cookie.load(self.view.request['HTTP_COOKIE'])
+        cookie.load(self.view.request["HTTP_COOKIE"])
         cookies = {k: c.value for k, c in cookie.items()}
         return cookies
 
@@ -49,15 +49,15 @@ class ZopeRequestAdapter(BaseAdapter):
     # =========================================================================
 
     def write(self, value):
-        logger.debug('write ' + value)
+        logger.debug("write " + value)
         self.view.request.response.write(value)
 
     def set_header(self, key, value):
-        logger.info('set_header ' + key + '=' + value)
+        logger.info("set_header " + key + "=" + value)
         self.view.request.response.setHeader(key, value)
 
     def set_status(self, status):
-        code, message = status.split(' ')
+        code, message = status.split(" ")
         code = int(code)
-        logger.debug('set_status {0}'.format(code))
+        logger.debug("set_status {0}".format(code))
         self.view.request.response.setStatus(code)

--- a/src/pas/plugins/authomatic/plugin.py
+++ b/src/pas/plugins/authomatic/plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import ClassSecurityInfo
-from App.class_init import InitializeClass
+from AccessControl.class_init import InitializeClass
 from BTrees.OOBTree import OOBTree
 from operator import itemgetter
 from pas.plugins.authomatic.interfaces import IAuthomaticPlugin

--- a/test_plone43.cfg
+++ b/test_plone43.cfg
@@ -8,8 +8,8 @@ extends =
 update-versions-file = test_plone43.cfg
 
 [versions]
-zc.buildout = 2.5.3
-setuptools = 27.3.0
+zc.buildout = 2.13.4
+setuptools = 38.7.0
 # Pillow = 5.1.0
 
 # manual pinnings
@@ -24,3 +24,55 @@ plone.protect = 3.0.0
 ###
 
 
+
+# Added by buildout at 2021-06-15 11:27:42.399377
+Authomatic = 1.0.0
+createcoverage = 1.5
+flake8 = 3.9.2
+flake8-coding = 1.3.2
+flake8-debugger = 4.0.0
+flake8-print = 4.0.0
+mccabe = 0.6.1
+pathtools = 0.1.2
+pkginfo = 1.7.0
+plone.app.dexterity = 2.0.19
+plone.recipe.codeanalysis = 3.0.1
+pyflakes = 2.3.1
+zipp = 1.2.0
+
+# Required by:
+# zest.releaser==6.13.5
+colorama = 0.4.4
+
+# Required by:
+# flake8==3.9.2
+enum34 = 1.1.10
+
+# Required by:
+# flake8==3.9.2
+functools32 = 3.2.3.post2
+
+# Required by:
+# importlib-metadata==1.3.0
+pathlib2 = 2.3.5
+
+# Required by:
+# check-manifest==0.41
+pep517 = 0.10.0
+
+# Required by:
+# flake8-debugger==4.0.0
+# flake8-print==4.0.0
+pycodestyle = 2.7.0
+
+# Required by:
+# pathlib2==2.3.5
+scandir = 1.10.0
+
+# Required by:
+# check-manifest==0.41
+toml = 0.10.2
+
+# Required by:
+# flake8==3.9.2
+typing = 3.10.0.0

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -20,9 +20,17 @@ mccabe = 0.6.1
 pathtools = 0.1.2
 plone.recipe.codeanalysis = 3.0.1
 prompt-toolkit = 1.0.16
-pyflakes = 1.5.0
+pyflakes = 2.3.0
 watchdog = 0.9.0
 
 # Required by:
 # prompt-toolkit==1.0.16
 wcwidth = 0.1.7
+
+# Added by buildout at 2021-06-03 09:53:42.271154
+flake8 = 3.9.2
+
+# Required by:
+# flake8-debugger==3.1.0
+# flake8-print==3.1.0
+pycodestyle = 2.7.0


### PR DESCRIPTION
Fixed ModuleNotFoundError: No module named 'App.class_init' on Zope 5.

But it also work on Zope > 5

We already make same changes there : https://github.com/plone/five.intid/pull/16/files