### PR TITLE
Fix method signature of doChangeUser

### DIFF
--- a/src/pas/plugins/authomatic/plugin.py
+++ b/src/pas/plugins/authomatic/plugin.py
@@ -291,7 +291,7 @@ class AuthomaticPlugin(BasePlugin):
         return self.removeUser(userid)
 
     @security.private
-    def doChangeUser(self, userid):
+    def doChangeUser(self, userid, password, **kw):
         """do nothing"""
         return False
 


### PR DESCRIPTION
This fixes a signature mismatch of `doChangeUser`, see `Products.PlonePAS.interfaces.plugins.IUserManagement.doChangeUser`


``` python
class IUserManagement(plugins.IUserAdderPlugin):
    """
    Manage users
    """

    def doChangeUser(user_id, password, **kw):
        """
        Change a user's password (differs from role) roles are set in
        the pas engine api for the same but are set via a role
        manager)
        """
```

When trying to change the password of a user, a `TypeError` otherwise is raised

Example code: 
``` python
import plone.api as api
acl_users = api.portal.get_tool('acl_users')
acl_users.userSetPassword(user.getUserId(), password)  # see Products.PlonePAS.pas.userSetPassword
```