### PR TITLE
Do not overwrite user with status returned from aclu._authorizeUser.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Changelog
 - Drop Plone < 5.1.x compatibility.
   [cekk]
 
+- Fix #54: Notification of PrincipalCreated event.
+  [ericof]
+
 1.0b1 (2017-11-20)
 ------------------
 

--- a/src/pas/plugins/authomatic/plugin.py
+++ b/src/pas/plugins/authomatic/plugin.py
@@ -138,7 +138,8 @@ class AuthomaticPlugin(BasePlugin):
         accessed, container, name, value = aclu._getObjectContext(
             self.REQUEST["PUBLISHED"], self.REQUEST
         )
-        user = aclu._authorizeUser(user, accessed, container, name, value, _noroles)
+        # Add the user to the SM stack
+        aclu._authorizeUser(user, accessed, container, name, value, _noroles)
         if do_notify_created:
             # be a good citizen in PAS world and notify user creation
             notify(PrincipalCreated(user))


### PR DESCRIPTION
Fixes #53 