### PR TITLE
Better handle values from identity data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.3 (unreleased)
 
 
-- Nothing changed yet.
+- Better handle values from identity data. @cekk
 
 
 ## 1.1.2 (2023-03-15)

--- a/src/pas/plugins/authomatic/tests/test_useridentities.py
+++ b/src/pas/plugins/authomatic/tests/test_useridentities.py
@@ -135,7 +135,7 @@ class TestUserIdentities(unittest.TestCase):
     def test_read_attribute_from_provider_data_if_default_is_none(self):
         PNAME = "mockhub"
         user = self._make_authomatic_user(
-            provider_name=PNAME, data={'email': 'jdoe@foobar.com'}
+            provider_name=PNAME, data={"email": "jdoe@foobar.com"}
         )
         user.email = None
         authomatic_result = MockResult(

--- a/src/pas/plugins/authomatic/tests/test_useridentities.py
+++ b/src/pas/plugins/authomatic/tests/test_useridentities.py
@@ -132,5 +132,24 @@ class TestUserIdentities(unittest.TestCase):
         self.assertEqual(sheet.getProperty("email"), "andrewpipkin@foobar.com")
         self.assertEqual(sheet.getProperty("customdomain"), "foobar.com")
 
+    def test_read_attribute_from_provider_data_if_default_is_none(self):
+        PNAME = "mockhub"
+        user = self._make_authomatic_user(
+            provider_name=PNAME,data={'email': 'jdoe@foobar.com'})
+        user.email = None
+        authomatic_result = MockResult(
+            user=user,
+            provider=MockResult(name=PNAME),
+        )
+        uis = make_user("mustermann")
+        uis.handle_result(authomatic_result)
+
+        # mock cfg
+        with mock.patch("pas.plugins.authomatic.useridentities.authomatic_cfg") as acfg:
+            cfg = self._make_cfg(PNAME)
+            acfg.return_value = cfg
+            sheet = uis.propertysheet
+        self.assertEqual(sheet.getProperty("email"), "jdoe@foobar.com")
+    
     def test_credentials(self):
         pass

--- a/src/pas/plugins/authomatic/tests/test_useridentities.py
+++ b/src/pas/plugins/authomatic/tests/test_useridentities.py
@@ -135,7 +135,8 @@ class TestUserIdentities(unittest.TestCase):
     def test_read_attribute_from_provider_data_if_default_is_none(self):
         PNAME = "mockhub"
         user = self._make_authomatic_user(
-            provider_name=PNAME,data={'email': 'jdoe@foobar.com'})
+            provider_name=PNAME, data={'email': 'jdoe@foobar.com'}
+        )
         user.email = None
         authomatic_result = MockResult(
             user=user,
@@ -150,6 +151,6 @@ class TestUserIdentities(unittest.TestCase):
             acfg.return_value = cfg
             sheet = uis.propertysheet
         self.assertEqual(sheet.getProperty("email"), "jdoe@foobar.com")
-    
+
     def test_credentials(self):
         pass

--- a/src/pas/plugins/authomatic/useridentities.py
+++ b/src/pas/plugins/authomatic/useridentities.py
@@ -71,7 +71,7 @@ class UserIdentities(Persistent):
             for akey, pkey in cfg.get("propertymap", {}).items():
                 # Always search first on the user attributes, then on the raw
                 # data this guaratees we do not break existing configurations
-                ainfo = identity.get(akey, identity["data"].get(akey, None))
+                ainfo = identity.get(akey, None) or identity["data"].get(akey, None)
                 if ainfo is None:
                     continue
                 if isinstance(pkey, dict):


### PR DESCRIPTION
This fix solves a problem that i had where the user had a None attribute (email) but the value from the provider were ignored.