### PR TITLE
Fix the authomatic view error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Search users by fullname and email. @alecghica
 - Fix login on Volto frontend when already logged-in in Plone Classic. @avoinea
 - Add the possibility to override the ZopeRequestAdapter.
+- Fix the authomatic view when it is reporting an exception that does not have a message attribute
 
 
 ## 1.2.0 (2023-09-13)

--- a/src/pas/plugins/authomatic/browser/view.py
+++ b/src/pas/plugins/authomatic/browser/view.py
@@ -123,7 +123,10 @@ class AuthomaticView(BrowserView):
             # let authomatic do its work
             return
         if result.error:
-            return result.error.message
+            try:
+                return result.error.message
+            except AttributeError:
+                return str(result.error)
         display = cfg[self.provider].get("display", {})
         provider_name = display.get("title", self.provider)
         if not self.is_anon:


### PR DESCRIPTION
Fix the authomatic view when it is reporting an exception that does not have a `message` attribute.

This happens, e.g. when you have a `ValueError`.

```
>>> ValueError().message
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'ValueError' object has no attribute 'message'
```