### PR TITLE
[1.4] Fix GHA

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,46 +5,26 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python:
-          - 3.7
-          - 3.8
-          - 3.9
-          - "3.10"
-          - "3.11"
-          - "3.12"
-        plone:
-          - "6.1-latest"
-          - "6.0-latest"
-          - "5.2-latest"
-        exclude:
+        include:
           - plone: "5.2-latest"
-            python: 3.9
+            python: "3.7"
+            os: "ubuntu-22.04"
           - plone: "5.2-latest"
-            python: "3.10"
-          - plone: "5.2-latest"
-            python: "3.11"
-          - plone: "5.2-latest"
-            python: "3.12"
+            python: "3.8"
+            os: "ubuntu-latest"
           - plone: "6.0-latest"
-            python: 3.7
+            python: "3.9"
+            os: "ubuntu-latest"
           - plone: "6.0-latest"
-            python: "3.12"
-          - plone: "6.1-latest"
-            python: 3.7
-          - plone: "6.1-latest"
-            python: 3.8
-          - plone: "6.1-latest"
-            python: 3.9
-          - plone: "6.1-latest"
             python: "3.10"
-          - plone: "6.1-latest"
+            os: "ubuntu-latest"
+          - plone: "6.0-latest"
             python: "3.11"
-          - plone: "6.1-latest"
-            python: "3.12"
+            os: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
With respect to before, this one no longer runs the test on Plone 6.0-latest and Python 3.8.
AFAIK, the last Plone 6 version really usable with Python 3.8 is 6.0.13.

Thanks @mauritsvanrees, for fixing the missing wheel for https://pypi.org/project/plone.restapi/7.9.0/#plone.restapi-7.9.0-py3-none-any.whl
