### PR TITLE
CI: test against Plone 6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
-        plone-version: ["6.1-latest", "6.0-latest"]
+        plone-version: ["6.2-latest", "6.1-latest", "6.0-latest"]
     with:
       python-version: ${{ matrix.python-version }}
       plone-version: ${{ matrix.plone-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
     needs:
       - config
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
         plone-version: ["6.2-latest", "6.1-latest", "6.0-latest"]

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ config: instance/etc/zope.ini
 requirements-mxdev.txt: ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
-	@uvx mxdev -c mx.ini
+	@uvx --from "mxdev[uv]" mxdev -c mx.ini
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"

--- a/news/104.internal
+++ b/news/104.internal
@@ -1,0 +1,1 @@
+Test against Plone 6.2 in CI.


### PR DESCRIPTION
Adds `6.2-latest` to the `plone-version` test matrix.

## Why

Plone 6.2.0 was released on 2026-05-19, and Volto 19 — the current maintained frontend — pairs with it. This package's CI currently tests only `6.1-latest` and `6.0-latest`, and the last release (2.0.0, 2025-05-15) predates 6.2, so there is no signal either way about whether it works.

Since `pas.plugins.authomatic` is often the only way editors authenticate, "does it work on 6.2" is a question a lot of sites will want answered before they upgrade.

## Does the matrix entry actually run?

Yes. `plone/meta`'s `backend-pytest.yml@2.x` passes `plone-version` straight to `plone/setup-plone`, which installs against `https://dist.plone.org/release/${plone-version}/constraints.txt`. That URL returns **200** for `6.2-latest`.

## Is it likely to pass?

Dependency resolution is clean — `pip install --dry-run pas.plugins.authomatic -c https://dist.plone.org/release/6.2-latest/constraints.txt` resolves without conflict.

The open question this PR is meant to answer is runtime behaviour, not resolution. Plone 6.2 moved its core packages from `pkg_resources`-style namespaces to PEP 420 native namespaces, and [the upgrade guide](https://6.docs.plone.org/backend/upgrading/version-specific-migration/upgrade-to-62.html) warns that mixing styles can raise `ModuleNotFoundError`. This package still declares an old-style namespace in `src/pas/__init__.py`:

```python
__import__("pkg_resources").declare_namespace(__name__)
```

That is not necessarily a problem yet — 6.2 pins `setuptools==81.0.0`, which only *deprecates* `pkg_resources` (removal landed in setuptools 82). But it does mean 6.2 is exactly where we would find out, and where a fix (native namespace) would want to land before setuptools 82 forces it.

If CI comes back green, this is just coverage. If it comes back red, the failure is worth knowing about regardless, and I am happy to follow up with the fix.

I have deliberately not touched the `Framework :: Plone :: 6.2` classifier — that should follow a green run, not precede it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9wenhxQPjyRgX5fSDjf8d
